### PR TITLE
Improve Application Versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,15 @@ DEFAULT: build
 GO           ?= go
 GOFMT        ?= $(GO)fmt
 DOCKER_ORG   := xmidt
+APP          := heimdall
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 HEIMDALL    := $(FIRST_GOPATH)/bin/heimdall
 
 PROGVER = $(shell git describe --tags `git rev-list --tags --max-count=1` | tail -1 | sed 's/v\(.*\)/\1/')
+RPM_VERSION=$(shell echo $(PROGVER) | sed 's/\(.*\)-\(.*\)/\1/')
+RPM_RELEASE=$(shell echo $(PROGVER) | sed -n 's/.*-\(.*\)/\1/p'  | grep . && (echo "$(echo $(PROGVER) | sed 's/.*-\(.*\)/\1/')") || echo "1")
+BUILDTIME = $(shell date -u '+%Y-%m-%d %H:%M:%S')
+GITCOMMIT = $(shell git rev-parse --short HEAD)
 
 .PHONY: go-mod-vendor
 go-mod-vendor:
@@ -18,16 +23,16 @@ build: go-mod-vendor
 
 rpm:
 	mkdir -p ./OPATH/SOURCES
-	tar -czvf ./OPATH/SOURCES/heimdall-$(PROGVER).tar.gz . --exclude ./.git --exclude ./OPATH --exclude ./conf --exclude ./deploy --exclude ./vendor
-	cp conf/heimdall.service ./OPATH/SOURCES/
-	cp conf/heimdall.yaml  ./OPATH/SOURCES/
+	tar -czvf ./OPATH/SOURCES/$(APP)-$(RPM_VERSION)-$(RPM_RELEASE).tar.gz . --exclude ./.git --exclude ./OPATH --exclude ./conf --exclude ./deploy --exclude ./vendor
+	cp conf/$(APP).service ./OPATH/SOURCES/
+	cp conf/$(APP).yaml  ./OPATH/SOURCES/
 	cp LICENSE ./OPATH/SOURCES/
 	cp NOTICE ./OPATH/SOURCES/
 	cp CHANGELOG.md ./OPATH/SOURCES/
 	rpmbuild --define "_topdir $(CURDIR)/OPATH" \
-    		--define "_version $(PROGVER)" \
-    		--define "_release 1" \
-    		-ba deploy/packaging/heimdall.spec
+		--define "_version $(RPM_VERSION)" \
+		--define "_release $(RPM_RELEASE)" \
+		-ba deploy/packaging/$(APP).spec
 
 .PHONY: version
 version:
@@ -45,26 +50,34 @@ endif
 .PHONY: update-version
 update-version:
 	@echo "Update Version $(PROGVER) to $(RUN_ARGS)"
-	sed -i "s/$(PROGVER)/$(RUN_ARGS)/g" main.go
+	git tag v$(RUN_ARGS)
 
 
 .PHONY: install
 install: go-mod-vendor
-	go install -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$(PROGVER)"
+	go install -ldflags "-X 'main.BuildTime=$(BUILDTIME)' -X main.GitCommit=$(GITCOMMIT) -X main.Version=$(PROGVER)"
 
 .PHONY: release-artifacts
 release-artifacts: go-mod-vendor
-	GOOS=darwin GOARCH=amd64 go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$(PROGVER)" -o ./OPATH/heimdall-$(PROGVER).darwin-amd64
-	GOOS=linux  GOARCH=amd64 go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$(PROGVER)" -o ./OPATH/heimdall-$(PROGVER).linux-amd64
+	GOOS=darwin GOARCH=amd64 go build -ldflags "-X 'main.BuildTime=$(BUILDTIME)' -X main.GitCommit=$(GITCOMMIT) -X main.Version=$(PROGVER)" -o ./OPATH/heimdall-$(PROGVER).darwin-amd64
+	GOOS=linux  GOARCH=amd64 go build -ldflags "-X 'main.BuildTime=$(BUILDTIME)' -X main.GitCommit=$(GITCOMMIT) -X main.Version=$(PROGVER)" -o ./OPATH/heimdall-$(PROGVER).linux-amd64
 
 .PHONY: docker
 docker:
-	docker build --build-arg VERSION=$(PROGVER) -f ./deploy/Dockerfile -t $(DOCKER_ORG)/heimdall:$(PROGVER) .
+	docker build \
+		--build-arg VERSION=$(PROGVER) \
+		--build-arg GITCOMMIT=$(GITCOMMIT) \
+		--build-arg BUILDTIME='$(BUILDTIME)' \
+		-f ./deploy/Dockerfile -t $(DOCKER_ORG)/heimdall:$(PROGVER) .
 
 # build docker without running modules
 .PHONY: local-docker
 local-docker:
-	docker build --build-arg VERSION=$(PROGVER)+local -f ./deploy/Dockerfile.local -t $(DOCKER_ORG)/heimdall:local .
+	docker build \
+		--build-arg VERSION=$(PROGVER)+local \
+		--build-arg GITCOMMIT=$(GITCOMMIT) \
+		--build-arg BUILDTIME='$(BUILDTIME)' \
+		-f ./deploy/Dockerfile.local -t $(DOCKER_ORG)/heimdall:local .
 
 .PHONY: style
 style:

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@ DEFAULT: build
 
 GO           ?= go
 GOFMT        ?= $(GO)fmt
+DOCKER_ORG   := xmidt
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 HEIMDALL    := $(FIRST_GOPATH)/bin/heimdall
 
-PROGVER = $(shell grep 'applicationVersion.*= ' main.go | awk '{print $$3}' | sed -e 's/\"//g')
+PROGVER = $(shell git describe --tags `git rev-list --tags --max-count=1` | tail -1 | sed 's/v\(.*\)/\1/')
 
 .PHONY: go-mod-vendor
 go-mod-vendor:
@@ -49,21 +50,21 @@ update-version:
 
 .PHONY: install
 install: go-mod-vendor
-	echo go build -o $(HEIMDALL) $(PROGVER)
+	go install -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$(PROGVER)"
 
 .PHONY: release-artifacts
 release-artifacts: go-mod-vendor
-	GOOS=darwin GOARCH=amd64 go build -o ./OPATH/heimdall-$(PROGVER).darwin-amd64
-	GOOS=linux  GOARCH=amd64 go build -o ./OPATH/heimdall-$(PROGVER).linux-amd64
+	GOOS=darwin GOARCH=amd64 go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$(PROGVER)" -o ./OPATH/heimdall-$(PROGVER).darwin-amd64
+	GOOS=linux  GOARCH=amd64 go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$(PROGVER)" -o ./OPATH/heimdall-$(PROGVER).linux-amd64
 
 .PHONY: docker
 docker:
-	docker build -f ./deploy/Dockerfile -t heimdall:$(PROGVER) .
+	docker build --build-arg VERSION=$(PROGVER) -f ./deploy/Dockerfile -t $(DOCKER_ORG)/heimdall:$(PROGVER) .
 
 # build docker without running modules
 .PHONY: local-docker
 local-docker:
-	docker build -f ./deploy/Dockerfile.local -t heimdall:local .
+	docker build --build-arg VERSION=$(PROGVER)+local -f ./deploy/Dockerfile.local -t $(DOCKER_ORG)/heimdall:local .
 
 .PHONY: style
 style:

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,13 +3,15 @@ MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/heimdall
 ARG VERSION=undefined
+ARG GITCOMMIT=undefined
+ARG BUILDTIME=undefined
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 
 COPY . .
 RUN GO111MODULE=on go mod vendor
-RUN GO111MODULE=on go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o heimdall_linux_amd64
+RUN GO111MODULE=on go build -ldflags "-X 'main.BuildTime=${BUILDTIME}' -X main.GitCommit=${GITCOMMIT} -X main.Version=${VERSION}" -o heimdall_linux_amd64
 
 FROM alpine
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -2,13 +2,14 @@ FROM golang:alpine as builder
 MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/heimdall
+ARG VERSION=undefined
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 
 COPY . .
 RUN GO111MODULE=on go mod vendor
-RUN GO111MODULE=on go build -o heimdall_linux_amd64
+RUN GO111MODULE=on go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o heimdall_linux_amd64
 
 FROM alpine
 

--- a/deploy/Dockerfile.local
+++ b/deploy/Dockerfile.local
@@ -3,12 +3,14 @@ MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/heimdall
 ARG VERSION=undefined
+ARG GITCOMMIT=undefined
+ARG BUILDTIME=undefined
 
 RUN apk add --update git curl
 
 COPY . .
 
-RUN go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o heimdall_linux_amd64
+RUN go build -ldflags "-X 'main.BuildTime=${BUILDTIME}' -X main.GitCommit=${GITCOMMIT} -X main.Version=${VERSION}" -o heimdall_linux_amd64
 
 FROM alpine
 

--- a/deploy/Dockerfile.local
+++ b/deploy/Dockerfile.local
@@ -2,12 +2,13 @@ FROM golang:alpine as builder
 MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/heimdall
+ARG VERSION=undefined
 
 RUN apk add --update git curl
 
 COPY . .
 
-RUN go build -o heimdall_linux_amd64
+RUN go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o heimdall_linux_amd64
 
 FROM alpine
 

--- a/deploy/packaging/heimdall.spec
+++ b/deploy/packaging/heimdall.spec
@@ -23,7 +23,7 @@ The shield to protect our users from incoming events for the codex project.
 aka. The receiver of data from XMiDT Caduceus
 
 %build
-GO111MODULE=on go build -o $RPM_SOURCE_DIR/%{name} %{_topdir}/..
+GO111MODULE=on go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=%{_version}" -o $RPM_SOURCE_DIR/%{name} %{_topdir}/..
 
 %install
 echo rm -rf %{buildroot}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintVersionInfo(t *testing.T) {
+	testCases := []struct {
+		name           string
+		expectedOutput []string
+		overrideValues func()
+		lineCount      int
+	}{
+		{
+			"default",
+			[]string{
+				"heimdall:",
+				"version: \tundefined",
+				"go version: \tgo",
+				"built time: \tundefined",
+				"git commit: \tundefined",
+				"os/arch: \t",
+			},
+			func() {},
+			6,
+		},
+		{
+			"set values",
+			[]string{
+				"heimdall:",
+				"version: \t1.0.0\n",
+				"go version: \tgo",
+				"built time: \tsome time\n",
+				"git commit: \tgit sha\n",
+				"os/arch: \t",
+			},
+			func() {
+				Version = "1.0.0"
+				BuildTime = "some time"
+				GitCommit = "git sha"
+			},
+			6,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetGlobals()
+			tc.overrideValues()
+			buf := &bytes.Buffer{}
+			printVersionInfo(buf)
+			count := 0
+			for {
+				line, err := buf.ReadString(byte('\n'))
+				if err != nil {
+					break
+				}
+				assert.Contains(t, line, tc.expectedOutput[count])
+				if strings.Contains(line, "\t") {
+					keyAndValue := strings.Split(line, "\t")
+					// The value after the tab should have more than 2 characters
+					// 1) the first character of the value and the new line
+					assert.True(t, len(keyAndValue[1]) > 2)
+				}
+				count++
+			}
+			assert.Equal(t, tc.lineCount, count)
+			resetGlobals()
+		})
+	}
+}
+
+func resetGlobals() {
+	Version = "undefined"
+	BuildTime = "undefined"
+	GitCommit = "undefined"
+}


### PR DESCRIPTION
This will allow for better bug reports and information the binary running.
This information can be retrieved upon providing the -v or --version
flag
Also, reordering the beginning of the method so that a user doesn't have
to provider all the flags in order to get the version information.

Closes #12 

```
docker run --rm xmidt/heimdall:local --version            
heimdall:
  version:      0.1.6+local
  go version:   go1.13.1
  built time:   2019-10-14 14:39:35
  git commit:   d46e60a
  os/arch:      linux/amd64
```