### PR TITLE
Security Release v0.3.1 Release - autoclosed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v0.3.1]
 - Migrate to github actions, normalize analysis tools, Dockerfiles and Makefiles. [#27](https://github.com/xmidt-org/heimdall/pull/27)
 - Updated references to the main branch [#23](https://github.com/xmidt-org/heimdall/pull/23)
 - bumped bascule to remove security vulnerability. [#31](https://github.com/xmidt-org/heimdall/pull/31)
 - Updated spec file and rpkg version macro to be able to choose when the 'v' is included in the version. [#32](https://github.com/xmidt-org/heimdall/pull/32)
+- Fix security vuln [CVE-2022-29526](https://github.com/advisories/GHSA-p782-xgp4-8hr8) https://github.com/xmidt-org/heimdall/issues/49
 
 ## [v0.3.0]
 - improve logging
@@ -45,7 +48,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added metric labels.
 - Bumped codex for `db` package updates.
 
-[Unreleased]: https://github.com/xmidt-org/heimdall/compare/0.3.0...HEAD
+[Unreleased]: https://github.com/xmidt-org/heimdall/compare/0.3.1...HEAD
+[v0.3.1]: https://github.com/xmidt-org/heimdall/compare/0.3.0...v0.3.1
 [v0.3.0]: https://github.com/xmidt-org/heimdall/compare/0.2.0...v0.3.0
 [v0.2.0]: https://github.com/xmidt-org/heimdall/compare/0.1.6...v0.2.0
 [v0.1.6]: https://github.com/xmidt-org/heimdall/compare/0.1.5...v0.1.6


### PR DESCRIPTION
- Patched Vulnerabilities
  - https://github.com/xmidt-org/heimdall/issues/49
  - bumped bascule to remove security vulnerability. [#31](https://github.com/xmidt-org/heimdall/pull/31)

Other things included
- Migrate to github actions, normalize analysis tools, Dockerfiles and Makefiles. [#27](https://github.com/xmidt-org/heimdall/pull/27)
- Updated references to the main branch [#23](https://github.com/xmidt-org/heimdall/pull/23)
- Updated spec file and rpkg version macro to be able to choose when the 'v' is included in the version. [#32](https://github.com/xmidt-org/heimdall/pull/32)

